### PR TITLE
added proper CMakeLists.txt to use as library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(pca9685
+			PCA9685_servo_driver.cpp
+			PCA9685_servo.cpp
+			)
+
+target_link_libraries(pca9685 PUBLIC
+		pico_stdlib
+		hardware_i2c
+		)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
-add_library(pca9685
+add_library(Adafruit-Servo-Driver-Library-Pi-Pico
 			PCA9685_servo_driver.cpp
 			PCA9685_servo.cpp
 			)
 
-target_link_libraries(pca9685 PUBLIC
+target_link_libraries(Adafruit-Servo-Driver-Library-Pi-Pico PUBLIC
 		pico_stdlib
 		hardware_i2c
 		)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,16 +22,16 @@ add_executable(${PROJECT_NAME}
 # Create map/bin/hex/uf2 files
 pico_add_extra_outputs(${PROJECT_NAME})
 
-add_subdirectory(pca9685)
+add_subdirectory(Adafruit-Servo-Driver-Library-Pi-Pico)
 
 target_include_directories(${PROJECT_NAME}
-    PRIVATE pca9685
+    PRIVATE Adafruit-Servo-Driver-Library-Pi-Pico
 )
 
 # Link to pico_stdlib (gpio, time, etc. functions)
 target_link_libraries(${PROJECT_NAME}
     pico_cyw43_arch_none
-	pca9685
+	Adafruit-Servo-Driver-Library-Pi-Pico
 )
 
 # Enable usb output, disable uart output

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,12 +17,12 @@ pico_sdk_init()
 # Tell CMake where to find the executable source file
 add_executable(${PROJECT_NAME}
     simple_servo.cpp
-    PCA9685_servo_driver.cpp
-    PCA9685_servo.cpp
 )
 
 # Create map/bin/hex/uf2 files
 pico_add_extra_outputs(${PROJECT_NAME})
+
+add_subdirectory(pca9685)
 
 target_include_directories(${PROJECT_NAME}
     PRIVATE pca9685
@@ -30,9 +30,8 @@ target_include_directories(${PROJECT_NAME}
 
 # Link to pico_stdlib (gpio, time, etc. functions)
 target_link_libraries(${PROJECT_NAME}
-    pico_stdlib
     pico_cyw43_arch_none
-    hardware_i2c
+	pca9685
 )
 
 # Enable usb output, disable uart output


### PR DESCRIPTION
Added CMakeLists.txt to the library folder, making it possible to link to like a library only by adding subdirectory and linking to target.